### PR TITLE
Removed `SameSite` and `Secure` when using `localhost` as cookie domain.

### DIFF
--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -60,39 +60,39 @@ func SetSession(sessionId string, response http.ResponseWriter, cookieDomain str
 
 	expire := time.Now().Add(cookieExpirationTime)
 	var cookie *http.Cookie
-	if cookieDomain == "localhost" {
-	  cookie = &http.Cookie{
-	    Name:     CookieName,
-	    Value:    encoded,
-	    Path:     "/",
-	    Expires:  expire,
-	    HttpOnly: true,
-	    MaxAge:   0, // to make sure that the browser does not persist it in disk
-	  }
-	} else if cookieDomain == "" {
-	  cookie = &http.Cookie{
-	    Name:     CookieName,
-	    Value:    encoded,
-	    Path:     "/",
-	    Expires:  expire,
-	    HttpOnly: true,
-	    SameSite: http.SameSiteNoneMode,
-	    Secure:   true,
-	    MaxAge:   0, // to make sure that the browser does not persist it in disk
-	  }
-	} else {
-	  cookie = &http.Cookie{
-	    Name:     CookieName,
-	    Value:    encoded,
-	    Path:     "/",
-	    Expires:  expire,
-	    HttpOnly: true,
-	    Domain:   cookieDomain,
-	    SameSite: http.SameSiteNoneMode,
-	    Secure:   true,
-	    MaxAge:   0, // to make sure that the browser does not persist it in disk
-	  }
-	}
+  if cookieDomain == "localhost" {
+    cookie = &http.Cookie{
+      Name:     CookieName,
+      Value:    encoded,
+      Path:     "/",
+      Expires:  expire,
+      HttpOnly: true,
+      MaxAge:   0, // to make sure that the browser does not persist it in disk
+    }
+   } else if cookieDomain == "" {
+    cookie = &http.Cookie{
+      Name:     CookieName,
+      Value:    encoded,
+      Path:     "/",
+      Expires:  expire,
+      HttpOnly: true,
+      SameSite: http.SameSiteNoneMode,
+      Secure:   true,
+      MaxAge:   0, // to make sure that the browser does not persist it in disk
+    }
+   } else {
+   cookie = &http.Cookie{
+      Name:     CookieName,
+      Value:    encoded,
+      Path:     "/",
+      Expires:  expire,
+      HttpOnly: true,
+      Domain:   cookieDomain,
+      SameSite: http.SameSiteNoneMode,
+      Secure:   true,
+      MaxAge:   0, // to make sure that the browser does not persist it in disk
+    }
+  }
 
 	http.SetCookie(response, cookie)
 	return nil

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -60,29 +60,38 @@ func SetSession(sessionId string, response http.ResponseWriter, cookieDomain str
 
 	expire := time.Now().Add(cookieExpirationTime)
 	var cookie *http.Cookie
-	if cookieDomain == "" {
-		cookie = &http.Cookie{
-			Name:     CookieName,
-			Value:    encoded,
-			Path:     "/",
-			Expires:  expire,
-			HttpOnly: true,
-			SameSite: http.SameSiteNoneMode,
-			Secure:   true,
-			MaxAge:   0, // to make sure that the browser does not persist it in disk
-		}
+	if cookieDomain == "localhost" {
+	  cookie = &http.Cookie{
+	    Name:     CookieName,
+	    Value:    encoded,
+	    Path:     "/",
+	    Expires:  expire,
+	    HttpOnly: true,
+	    MaxAge:   0, // to make sure that the browser does not persist it in disk
+	  }
+	} else if cookieDomain == "" {
+	  cookie = &http.Cookie{
+	    Name:     CookieName,
+	    Value:    encoded,
+	    Path:     "/",
+	    Expires:  expire,
+	    HttpOnly: true,
+	    SameSite: http.SameSiteNoneMode,
+	    Secure:   true,
+	    MaxAge:   0, // to make sure that the browser does not persist it in disk
+	  }
 	} else {
-		cookie = &http.Cookie{
-			Name:     CookieName,
-			Value:    encoded,
-			Path:     "/",
-			Expires:  expire,
-			HttpOnly: true,
-			Domain:   cookieDomain,
-			SameSite: http.SameSiteNoneMode,
-			Secure:   true,
-			MaxAge:   0, // to make sure that the browser does not persist it in disk
-		}
+	  cookie = &http.Cookie{
+	    Name:     CookieName,
+	    Value:    encoded,
+	    Path:     "/",
+	    Expires:  expire,
+	    HttpOnly: true,
+	    Domain:   cookieDomain,
+	    SameSite: http.SameSiteNoneMode,
+	    Secure:   true,
+	    MaxAge:   0, // to make sure that the browser does not persist it in disk
+	  }
 	}
 
 	http.SetCookie(response, cookie)

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -60,39 +60,39 @@ func SetSession(sessionId string, response http.ResponseWriter, cookieDomain str
 
 	expire := time.Now().Add(cookieExpirationTime)
 	var cookie *http.Cookie
-  if cookieDomain == "localhost" {
-    cookie = &http.Cookie{
-      Name:     CookieName,
-      Value:    encoded,
-      Path:     "/",
-      Expires:  expire,
-      HttpOnly: true,
-      MaxAge:   0, // to make sure that the browser does not persist it in disk
-    }
-   } else if cookieDomain == "" {
-    cookie = &http.Cookie{
-      Name:     CookieName,
-      Value:    encoded,
-      Path:     "/",
-      Expires:  expire,
-      HttpOnly: true,
-      SameSite: http.SameSiteNoneMode,
-      Secure:   true,
-      MaxAge:   0, // to make sure that the browser does not persist it in disk
-    }
-   } else {
-   cookie = &http.Cookie{
-      Name:     CookieName,
-      Value:    encoded,
-      Path:     "/",
-      Expires:  expire,
-      HttpOnly: true,
-      Domain:   cookieDomain,
-      SameSite: http.SameSiteNoneMode,
-      Secure:   true,
-      MaxAge:   0, // to make sure that the browser does not persist it in disk
-    }
-  }
+	if cookieDomain == "localhost" {
+		cookie = &http.Cookie{
+			Name:     CookieName,
+			Value:    encoded,
+			Path:     "/",
+			Expires:  expire,
+			HttpOnly: true,
+			MaxAge:   0, // to make sure that the browser does not persist it in disk
+		}
+	} else if cookieDomain == "" {
+		cookie = &http.Cookie{
+			Name:     CookieName,
+			Value:    encoded,
+			Path:     "/",
+			Expires:  expire,
+			HttpOnly: true,
+			SameSite: http.SameSiteNoneMode,
+			Secure:   true,
+			MaxAge:   0, // to make sure that the browser does not persist it in disk
+		}
+	} else {
+		cookie = &http.Cookie{
+			Name:     CookieName,
+			Value:    encoded,
+			Path:     "/",
+			Expires:  expire,
+			HttpOnly: true,
+			Domain:   cookieDomain,
+			SameSite: http.SameSiteNoneMode,
+			Secure:   true,
+			MaxAge:   0, // to make sure that the browser does not persist it in disk
+		}
+	}
 
 	http.SetCookie(response, cookie)
 	return nil


### PR DESCRIPTION
As highlighted in issue https://github.com/fairDataSociety/fairOS-dfs/issues/52 cookies cannot be acquired when fairOS-dfs is run locally while at least `SameSite` is active and `Secure` forces SSL.

Also you'll only get the cookie with certain clients. If you want to get the cookie with client side JS, like most dApps would, you'll need to drop `HttpOnly` since it removes the ability to nab the cookie from `document.cookie`.

Currently my dApp is running locally alongside `fairOS-dfs`. It's unclear how dApps will package with `fairOS-dfs` in the future but assuming they're pulled from Swarm and running locally on the users machine this may be necessary or end-users will be required to generate SSL certs.

All in all these securities only make sense for remote hosts. If the apps are running side-by-side fairOS-dfs, this will be the way to allow it for now.

I updated the conditional statements to include consideration for `cookieDomain == "localhost"` and I was able to get the cookie. We may simply want to include this under case "" but I'll leave that open for discussion.

