### PR TITLE
Resolved issues with cookies and localhost dApps.

### DIFF
--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -60,7 +60,18 @@ func SetSession(sessionId string, response http.ResponseWriter, cookieDomain str
 
 	expire := time.Now().Add(cookieExpirationTime)
 	var cookie *http.Cookie
-	if cookieDomain == "" {
+	if cookieDomain == "localhost" {
+		cookie = &http.Cookie{
+			Name:    CookieName,
+			Value:   encoded,
+			Path:    "/",
+			Expires: expire,
+			//SameSite: http.SameSiteNoneMode, // Can't have SameSite || Secure on localhost or cookie will be blocked
+			//Secure:   true, // Can't have SameSite || Secure on localhost or cookie will be blocked
+			//HttpOnly: true, // Can't have this on localhost or cookie will be inaccessibe via document.cookie
+			MaxAge: 0, // to make sure that the browser does not persist it in disk
+		}
+	} else if cookieDomain == "" {
 		cookie = &http.Cookie{
 			Name:     CookieName,
 			Value:    encoded,


### PR DESCRIPTION
As highlighted in issue https://github.com/fairDataSociety/fairOS-dfs/issues/52 cookies cannot be acquired when fairOS-dfs is run locally while at least `SameSite` is active and `Secure` forces SSL.

Also you'll only get the cookie with certain clients. If you want to get the cookie with client side JS, like most dApps would, you'll need to drop `HttpOnly` since it removes the ability to nab the cookie from `document.cookie`.

Currently my dApp is running locally alongside `fairOS-dfs`. It's unclear how dApps will package with `fairOS-dfs` in the future but assuming they're pulled from Swarm and running locally on the users machine this may be necessary or end-users will be required to generate SSL certs.

All in all these securities only make sense for remote hosts. If the apps are running side-by-side fairOS-dfs, this will be the way to allow it for now.

I updated the conditional statements to include consideration for `cookieDomain == "localhost"` and I was able to get the cookie. We may simply want to include this under case "" but I'll leave that open for discussion.

