### PR TITLE
openapi docs pod receive query parameter fixed

### DIFF
--- a/openapi/dfs.yaml
+++ b/openapi/dfs.yaml
@@ -309,10 +309,10 @@ paths:
           schema:
             type: object
             properties:
-              reference:
+              sharing_ref:
                 $ref: '#/components/schemas/FileSharingReference'
             required:
-              - reference
+              - sharing_ref
       responses:
         '200':
           description: 'OK'
@@ -341,10 +341,10 @@ paths:
           schema:
             type: object
             properties:
-              reference:
+              sharing_ref:
                 $ref: '#/components/schemas/FileSharingReference'
             required:
-              - reference
+              - sharing_ref
       responses:
         '200':
           description: 'OK'


### PR DESCRIPTION
In Openapi docs:
Receive pod's query parameter must be "sharing_ref".